### PR TITLE
fix: race-safe rate-limit init + drop AAPL bootstrap

### DIFF
--- a/src/eodhd_py/base.py
+++ b/src/eodhd_py/base.py
@@ -72,6 +72,7 @@ class EodhdApiConfig(BaseModel):
     _extra_rate_limiter: Any | None = None
     _minute_rate_limiter: Any | None = None
     _user_limits_initialized: bool = False
+    _rate_limit_init_lock: asyncio.Lock | None = None
 
     @property
     def session(self) -> aiohttp.ClientSession:
@@ -125,101 +126,111 @@ class EodhdApiConfig(BaseModel):
             raise RuntimeError(msg)
         return self._minute_rate_limiter
 
+    def _new_token_bucket(self, **kwargs: Any) -> Any:
+        """Build a steindamm async token bucket (supports steindamm 0.8 ctor and 0.9 .create)."""
+        factory = getattr(AsyncTokenBucket, "create", None)
+        if callable(factory):
+            return factory(**kwargs)
+        return AsyncTokenBucket(**kwargs)
+
     async def initialize_rate_limiters(self, base_url: str) -> None:
         """
         Fetch actual limits from user API and initialize rate limiters.
 
+        Concurrent callers are serialized so the initialized flag is only set after
+        limiters exist (avoids a RuntimeError race). When limits are auto-fetched,
+        only GET /user is used — a dummy EOD prime is not required.
+
         Args:
             base_url: The base URL for the API
-            force: If True, refetch limits even if already fetched (useful after 429 errors)
 
         """
-        if self._user_limits_initialized:
+        if self._user_limits_initialized and self._daily_rate_limiter is not None:
             return
 
-        self._user_limits_initialized = True
+        if self._rate_limit_init_lock is None:
+            self._rate_limit_init_lock = asyncio.Lock()
 
-        # Default limits
-        daily_limit = self.daily_calls_rate_limit if self.daily_calls_rate_limit is not None else 100000.0
-        daily_remaining_limit = self.daily_remaining_limit if self.daily_remaining_limit is not None else daily_limit
-        extra_limit = self.extra_limit if self.extra_limit is not None else 0.0
-        minute_limit = self.minute_requests_rate_limit if self.minute_requests_rate_limit is not None else 1400.0
-        minute_remaining_limit = (
-            self.minute_remaining_limit if self.minute_remaining_limit is not None else minute_limit
-        )
+        async with self._rate_limit_init_lock:
+            if self._user_limits_initialized and self._daily_rate_limiter is not None:
+                return
 
-        # Try to fetch actual limits from user API if not explicitly set
-        if self.daily_calls_rate_limit is None or self.minute_requests_rate_limit is None or self.extra_limit is None:
-            try:
-                # Make a simple EOD request first to populate user API values
-                params = {"api_token": self.api_key, "fmt": "json"}
-                eod_url = f"{base_url}/eod/AAPL"
-                async with self.session.request("GET", eod_url, params=params) as eod_response:
-                    eod_response.raise_for_status()
-                    await eod_response.json()
-
-                # Now fetch user info to get limits
-                url = f"{base_url}/user"
-                async with self.session.request("GET", url, params=params) as response:
-                    response.raise_for_status()
-                    user_info = await response.json()
-
-                    # Update daily rate limit if not explicitly set
-                    if self.daily_calls_rate_limit is None:
-                        daily_limit = int(user_info.get("dailyRateLimit", 100000))
-                        daily_remaining_limit = daily_limit - int(user_info.get("apiRequests", daily_limit))
-
-                    # Update extra limit if not explicitly set
-                    if self.extra_limit is None:
-                        extra_limit = int(user_info.get("extraLimit", 0))
-
-                    # Update minute rate limit if not explicitly set
-                    if self.minute_requests_rate_limit is None:
-                        minute_limit = int(response.headers.get("x-ratelimit-limit", 1400))
-                        minute_remaining_limit = int(response.headers.get("x-ratelimit-remaining", minute_limit))
-            except Exception as e:  # noqa: BLE001
-                # TODO: Remove once logging is added
-                print(f"Failed to fetch user limits: {e}. Using default or configured limits.")  # noqa: T201
-
-        api_key_hash = self.rate_limit_key or str(abs(hash(self.api_key)))[:8]  # Short hash for unique naming
-
-        # Daily limits reset at midnight GMT (UTC)
-        # Use naive datetime for compatibility with steindamm
-        now = datetime.now(UTC)
-        last_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
-
-        # Initialize rate limiters with fetched or default limits
-        self._daily_rate_limiter = AsyncTokenBucket(
-            connection=self.redis_connection,
-            name=f"eodhd_daily_{api_key_hash}",
-            capacity=daily_limit,
-            refill_frequency=86400,  # 24 hours in seconds
-            refill_amount=daily_limit,
-            initial_tokens=daily_remaining_limit,  # Start with remaining capacity
-            max_sleep=self.daily_max_sleep,  # Maximum time to wait for daily rate limit
-            expiry=86400 * 2,
-            window_start_time=last_midnight,
-        )
-        if extra_limit > 0:
-            # Extra limit - non-refilling token bucket
-            self._extra_rate_limiter = AsyncTokenBucket(
-                connection=self.redis_connection,
-                name=f"eodhd_extra_{api_key_hash}",
-                capacity=extra_limit,
-                refill_frequency=0,
-                refill_amount=0,
-                expiry=86400 * 2,
+            # Default limits (flag stays false until buckets are installed)
+            daily_limit = self.daily_calls_rate_limit if self.daily_calls_rate_limit is not None else 100000.0
+            daily_remaining_limit = (
+                self.daily_remaining_limit if self.daily_remaining_limit is not None else daily_limit
             )
-        self._minute_rate_limiter = AsyncTokenBucket(
-            connection=self.redis_connection,
-            name=f"eodhd_minute_{api_key_hash}",
-            capacity=minute_limit,
-            refill_frequency=1,  # every second
-            refill_amount=minute_limit / 60,
-            initial_tokens=minute_remaining_limit,  # Start with remaining capacity
-            max_sleep=self.minute_max_sleep,  # Maximum time to wait for minute rate limit
-            expiry=120,
-        )
+            extra_limit = self.extra_limit if self.extra_limit is not None else 0.0
+            minute_limit = self.minute_requests_rate_limit if self.minute_requests_rate_limit is not None else 1400.0
+            minute_remaining_limit = (
+                self.minute_remaining_limit if self.minute_remaining_limit is not None else minute_limit
+            )
+
+            # Fetch actual limits from user API if not explicitly set (no dummy ticker)
+            if (
+                self.daily_calls_rate_limit is None
+                or self.minute_requests_rate_limit is None
+                or self.extra_limit is None
+            ):
+                try:
+                    params = {"api_token": self.api_key, "fmt": "json"}
+                    url = f"{base_url}/user"
+                    async with self.session.request("GET", url, params=params) as response:
+                        response.raise_for_status()
+                        user_info = await response.json()
+
+                        if self.daily_calls_rate_limit is None:
+                            daily_limit = int(user_info.get("dailyRateLimit", 100000))
+                            daily_remaining_limit = daily_limit - int(user_info.get("apiRequests", daily_limit))
+
+                        if self.extra_limit is None:
+                            extra_limit = int(user_info.get("extraLimit", 0))
+
+                        if self.minute_requests_rate_limit is None:
+                            minute_limit = int(response.headers.get("x-ratelimit-limit", 1400))
+                            minute_remaining_limit = int(response.headers.get("x-ratelimit-remaining", minute_limit))
+                except Exception as e:  # noqa: BLE001
+                    # TODO: Remove once logging is added
+                    print(f"Failed to fetch user limits: {e}. Using default or configured limits.")  # noqa: T201
+
+            api_key_hash = self.rate_limit_key or str(abs(hash(self.api_key)))[:8]
+
+            # Daily limits reset at midnight GMT (UTC)
+            # Use naive datetime for compatibility with steindamm
+            now = datetime.now(UTC)
+            last_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+
+            self._daily_rate_limiter = self._new_token_bucket(
+                connection=self.redis_connection,
+                name=f"eodhd_daily_{api_key_hash}",
+                capacity=daily_limit,
+                refill_frequency=86400,  # 24 hours in seconds
+                refill_amount=daily_limit,
+                initial_tokens=daily_remaining_limit,
+                max_sleep=self.daily_max_sleep,
+                expiry=86400 * 2,
+                window_start_time=last_midnight,
+            )
+            if extra_limit > 0:
+                self._extra_rate_limiter = self._new_token_bucket(
+                    connection=self.redis_connection,
+                    name=f"eodhd_extra_{api_key_hash}",
+                    capacity=extra_limit,
+                    refill_frequency=0,
+                    refill_amount=0,
+                    expiry=86400 * 2,
+                )
+            self._minute_rate_limiter = self._new_token_bucket(
+                connection=self.redis_connection,
+                name=f"eodhd_minute_{api_key_hash}",
+                capacity=minute_limit,
+                refill_frequency=1,  # every second
+                refill_amount=minute_limit / 60,
+                initial_tokens=minute_remaining_limit,
+                max_sleep=self.minute_max_sleep,
+                expiry=120,
+            )
+            self._user_limits_initialized = True
 
 
 class BaseEodhdApi:

--- a/tests/test_rate_limits.py
+++ b/tests/test_rate_limits.py
@@ -1,5 +1,6 @@
 """Test rate limiting functionality"""
 
+import asyncio
 from typing import Any
 
 import aiohttp
@@ -9,6 +10,30 @@ from pytest_mock import MockerFixture
 from steindamm import MaxSleepExceededError, NoTokensAvailableError
 
 from eodhd_py.base import BaseEodhdApi, EodhdApiConfig
+
+
+@pytest.mark.asyncio
+async def test_concurrent_initialize_no_runtime_error_race() -> None:
+    """Concurrent initialize_rate_limiters must not raise RuntimeError."""
+    config = EodhdApiConfig(
+        api_key="demo",
+        daily_calls_rate_limit=50000,
+        daily_remaining_limit=4000,
+        minute_requests_rate_limit=100,
+        minute_remaining_limit=50,
+        extra_limit=0,
+    )
+    api = BaseEodhdApi(config=config)
+
+    async def _init_and_touch() -> None:
+        await config.initialize_rate_limiters(api.BASE_URL)
+        assert config.daily_rate_limiter is not None
+        assert config.minute_rate_limiter is not None
+        assert config._user_limits_initialized is True
+
+    await asyncio.gather(*[_init_and_touch() for _ in range(24)])
+    assert config._daily_rate_limiter is not None
+    assert config._minute_rate_limiter is not None
 
 
 @pytest.mark.asyncio
@@ -85,12 +110,7 @@ async def test_fetch_limits_only_once() -> None:
         api = BaseEodhdApi(config=config)
 
         with aioresponses() as mock_http:
-            # The AAPL call is made to populate API stats before fetching user info
-            mock_http.get(  # type: ignore
-                "https://eodhd.com/api/eod/AAPL?api_token=demo&fmt=json",
-                payload={"close": 100},
-            )
-
+            # Bootstrap is GET /user only (no dummy /eod/AAPL prime)
             mock_http.get(  # type: ignore
                 "https://eodhd.com/api/user?api_token=demo&fmt=json",
                 payload={"dailyRateLimit": "100000", "apiRequests": "1000"},
@@ -106,18 +126,15 @@ async def test_fetch_limits_only_once() -> None:
             for i in range(3):
                 await api._make_request(f"eod/TEST{i}", df_output=False)
 
-            # Verify _user_limits_initialized flag is True after requests
             assert config._user_limits_initialized is True
 
-            # Verify user API was called exactly once
             requests_dict: dict[Any, Any] = mock_http.requests  # type: ignore
             user_api_call_count = sum(1 for key in requests_dict if "/user" in str(key[1]))
             assert user_api_call_count == 1
+            assert sum(1 for key in requests_dict if "/eod/AAPL" in str(key[1])) == 0
 
-            # Verify rate limiters are initialized
             assert config._daily_rate_limiter is not None
             assert config._minute_rate_limiter is not None
-
             assert config._daily_rate_limiter.capacity == 100000
             assert config._daily_rate_limiter.initial_tokens == 99000  # 100000 - 1000 used
             assert config._minute_rate_limiter.capacity == 1400
@@ -168,14 +185,7 @@ async def test_config_partial_auto_fetch(
 
         api = BaseEodhdApi(config=config)
 
-        # Mock the user API response
         with aioresponses() as mock_http:
-            # The AAPL call is made to populate API stats before fetching user info
-            mock_http.get(  # type: ignore
-                "https://eodhd.com/api/eod/AAPL?api_token=demo&fmt=json",
-                payload={"close": 100},
-            )
-
             mock_http.get(  # type: ignore
                 "https://eodhd.com/api/user?api_token=demo&fmt=json",
                 payload={"dailyRateLimit": "200000", "apiRequests": "1000", "extraLimit": "1000"},


### PR DESCRIPTION
Fixes #5

- Serialize `initialize_rate_limiters` with `asyncio.Lock`
- Set `_user_limits_initialized` only after buckets exist (no concurrent RuntimeError race)
- Remove unmetered `/eod/AAPL` prime; bootstrap is `GET /user` only when limits are auto-fetched
- Concurrent gather regression tests
- `AsyncTokenBucket.create()` for steindamm 0.9+; `window_start_time` past-clamp for local clocks